### PR TITLE
RD-1073: Populate realm for affiliated TPPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ To use the SDK, add the [Nuget](https://www.nuget.org/packages/Token.SDK.Net/) p
 
 <div class="codediv"><pre>
 &lt;ItemGroup>
-    &lt;PackageReference Include="Token.SDK.Net" Version="1.0.7" />
+    &lt;PackageReference Include="Token.SDK.Net" Version="1.0.8" />
 &lt;/ItemGroup>
 </pre></div>

--- a/build_proto.rb
+++ b/build_proto.rb
@@ -1,8 +1,8 @@
 #
 # Fetches specified proto files from the artifact repository.
 #
-TOKEN_PROTOS_VER = "1.1.0"
-RPC_PROTOS_VER = "1.0.124"
+TOKEN_PROTOS_VER = "1.1.16"
+RPC_PROTOS_VER = "1.1.0"
 
 require 'open-uri'
 

--- a/sdk/Properties/AssemblyInfo.cs
+++ b/sdk/Properties/AssemblyInfo.cs
@@ -12,4 +12,4 @@ using log4net.Config;
 
 [assembly: XmlConfigurator(ConfigFile = "log4net.config")]
 
-[assembly: AssemblyVersion("1.0.7")]
+[assembly: AssemblyVersion("1.0.8")]

--- a/sdk/src/Exceptions/InvalidRealmException.cs
+++ b/sdk/src/Exceptions/InvalidRealmException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Tokenio.Exceptions
+{
+    public class InvalidRealmException : Exception
+    {
+        public InvalidRealmException(string actual, string expected) 
+            : base($"Invalid realm {actual}; expected {expected}")
+        {
+        }
+    }
+}


### PR DESCRIPTION
TPPs who are affiliated with a partner (have partnerId set) can only own realms in the partner's realm (=partnerId).

We automatically populate realm for these TPPs so that users of the SDK don't need to do it themselves.