### PR TITLE
Rd-3764: createSigner by Id (important for recovery); add tests for core

### DIFF
--- a/core-tests/CollectionAssert.cs
+++ b/core-tests/CollectionAssert.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Test
+{
+    public static class CollectionAssert
+    {
+        public static void Equivalent<T>(IEnumerable<T> c1, IEnumerable<T> c2)
+        {
+            var d1 = ToDictionary(c1);
+            var d2 = ToDictionary(c2);
+            Assert.Equal(d1, d2);
+        }
+
+        private static IDictionary<T, int> ToDictionary<T>(IEnumerable<T> collection)
+        {
+            var dictionary = new Dictionary<T, int>();
+            foreach (var item in collection)
+            {
+                if (dictionary.ContainsKey(item))
+                {
+                    dictionary[item]++;
+                }
+                else
+                {
+                    dictionary[item] = 1;
+                }
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/core-tests/CoreTests.csproj
+++ b/core-tests/CoreTests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\core\Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/core-tests/Security/CryptoEngineTest.cs
+++ b/core-tests/Security/CryptoEngineTest.cs
@@ -1,0 +1,79 @@
+﻿using System.Security.Cryptography;
+using Xunit;
+using Tokenio.Proto.Common.AliasProtos;
+using Tokenio.Security;
+using Tokenio.Utils;
+using static Tokenio.Proto.Common.AliasProtos.Alias.Types.Type;
+using static Tokenio.Proto.Common.SecurityProtos.Key.Types.Level;
+
+namespace Test.Security
+{
+    public class CryptoEngineTest
+    {
+        private string memberId;
+        private IKeyStore keyStore;
+        private ICryptoEngine cryptoEngine;
+
+        public CryptoEngineTest()
+        {
+            memberId = Util.Nonce();
+            keyStore = new InMemoryKeyStore();
+            cryptoEngine = new TokenCryptoEngine(memberId, keyStore);
+        }
+
+        [Fact]
+        public void VerifierTest()
+        {
+            var signature = "tPmCXbpIf-lR2sOJrlB3wviI-mybLwKomo6Vh3Lxaf9RmS7FDiL5zdDxa8m5JvoVBMW4MnqHn5zUaKecESjjBQ";
+            var payload = "{\"type\":\"EMAIL\",\"value\":\"123\"}";
+            var verifier = new Ed25519Veifier("ypQFEgdQe-E8u1dtpmAhAE0EoaGdvP5lNc0P4wgY2DA");
+            verifier.Verify(payload, signature);
+        }
+
+        [Fact]
+        public void SignAndVerify_string()
+        {
+            cryptoEngine.GenerateKey(Privileged);
+            var signer = cryptoEngine.CreateSigner(Privileged);
+            var payload = Util.Nonce();
+            var signature = signer.Sign(payload);
+            var verifier = cryptoEngine.CreateVerifier(signer.GetKeyId());
+            verifier.Verify(payload, signature);
+        }
+
+        [Fact]
+        public void SignAndVerify_protobuf()
+        {
+            cryptoEngine.GenerateKey(Privileged);
+            var signer = cryptoEngine.CreateSigner(Privileged);
+            var payload = new Alias{Value = "bob@token.io", Type = Email};
+            var signature = signer.Sign(payload);
+            var verifier = cryptoEngine.CreateVerifier(signer.GetKeyId());
+            verifier.Verify(payload, signature);
+        }
+
+        [Fact]
+        public void WrongKey()
+        {
+            cryptoEngine.GenerateKey(Privileged);
+            var signer = cryptoEngine.CreateSigner(Privileged);
+            var newKey = cryptoEngine.GenerateKey(Privileged);
+            var payload = Util.Nonce();
+            var signature = signer.Sign(payload);
+            var verifier = cryptoEngine.CreateVerifier(newKey.Id);
+            Assert.Throws<CryptographicException>(() => verifier.Verify(payload, signature));
+        }
+
+        [Fact]
+        public void useOldKey()
+        {
+            var oldKey = cryptoEngine.GenerateKey(Privileged);
+            cryptoEngine.GenerateKey(Privileged);
+            var signer = cryptoEngine.CreateSigner(oldKey.Id);
+            var payload = Util.Nonce();
+            var signature = signer.Sign(payload);
+            var verifier = cryptoEngine.CreateVerifier(oldKey.Id);
+            verifier.Verify(payload, signature);
+        }
+    }
+}

--- a/core-tests/Security/InMemoryKeyStoreTest.cs
+++ b/core-tests/Security/InMemoryKeyStoreTest.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using Xunit;
+using Tokenio.Security;
+using Tokenio.Utils;
+using static Tokenio.Proto.Common.SecurityProtos.Key.Types.Level;
+using KeyPair = Tokenio.Security.KeyPair;
+
+namespace Test.Security
+{
+    public class InMemoryKeyStoreTest
+    {
+        private IKeyStore keyStore;
+        private string memberId;
+
+        public InMemoryKeyStoreTest()
+        {
+            keyStore = new InMemoryKeyStore();
+            memberId = Util.Nonce();
+        }
+
+        [Fact]
+        public void GetByLevel()
+        {
+            var privileged = TestUtil.GenerateKeyPair(Privileged);
+            var standard = TestUtil.GenerateKeyPair(Standard);
+            var low = TestUtil.GenerateKeyPair(Low);
+            keyStore.Put(memberId, privileged);
+            keyStore.Put(memberId, standard);
+            keyStore.Put(memberId, low);
+            Assert.Equal(privileged, keyStore.GetByLevel(memberId, Privileged));
+            Assert.Equal(standard, keyStore.GetByLevel(memberId, Standard));
+            Assert.Equal(low, keyStore.GetByLevel(memberId, Low));
+        }
+
+        [Fact]
+        public void GetById()
+        {
+            var key1 = TestUtil.GenerateKeyPair(Privileged);
+            var key2 = TestUtil.GenerateKeyPair(Privileged);
+            keyStore.Put(memberId, key1);
+            keyStore.Put(memberId, key2);
+            Assert.Equal(key1, keyStore.GetById(memberId, key1.Id));
+            Assert.Equal(key2, keyStore.GetById(memberId, key2.Id));
+        }
+
+        [Fact]
+        public void KeyList()
+        {
+            var privileged = TestUtil.GenerateKeyPair(Privileged);
+            var standard = TestUtil.GenerateKeyPair(Standard);
+            var low = TestUtil.GenerateKeyPair(Low);
+            keyStore.Put(memberId, privileged);
+            keyStore.Put(memberId, standard);
+            keyStore.Put(memberId, low);
+            var keyList = new List<KeyPair> {privileged, standard, low};
+            CollectionAssert.Equivalent(keyStore.KeyList(memberId), keyList);
+        }
+
+        [Fact]
+        public void DifferentMember()
+        {
+            var member2 = Util.Nonce();
+            var key1 = TestUtil.GenerateKeyPair(Privileged);
+            var key2 = TestUtil.GenerateKeyPair(Privileged);
+            keyStore.Put(memberId, key1);
+            keyStore.Put(member2, key2);
+            Assert.Equal(key1, keyStore.GetById(memberId, key1.Id));
+            Assert.Equal(key2, keyStore.GetById(member2, key2.Id));
+        }
+    }
+}

--- a/core-tests/Security/UnsecuredFileSystemKeyStoreTest.cs
+++ b/core-tests/Security/UnsecuredFileSystemKeyStoreTest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using Tokenio;
+using Tokenio.Security;
+using Tokenio.Utils;
+using static Tokenio.Proto.Common.SecurityProtos.Key.Types.Level;
+using KeyPair = Tokenio.Security.KeyPair;
+
+namespace Test.Security
+{
+    public class UnsecuredFileSystemKeyStoreTest : IDisposable
+    {
+        private readonly string directory = "./testKeys";
+
+        private readonly string memberId1 = Util.Nonce() + ":" + Util.Nonce();
+        private readonly string memberId2 = Util.Nonce() + ":" + Util.Nonce();
+
+        private readonly KeyPair privileged = TestUtil.GenerateKeyPair(Privileged);
+        private readonly KeyPair standard = TestUtil.GenerateKeyPair(Standard);
+        private readonly KeyPair lowOld = TestUtil.GenerateKeyPair(Low);
+        private readonly KeyPair lowNew = TestUtil.GenerateKeyPair(Low);
+
+        public UnsecuredFileSystemKeyStoreTest()
+        {
+            var keyStore = new UnsecuredFileSystemKeyStore(directory);
+            keyStore.Put(memberId1, standard);
+            keyStore.Put(memberId1, lowOld);
+            keyStore.Put(memberId1, lowNew);
+            keyStore.Put(memberId2, privileged);
+
+            Assert.Equal(standard, keyStore.GetByLevel(memberId1, Standard));
+            Assert.Equal(lowNew, keyStore.GetByLevel(memberId1, Low));
+            CollectionAssert.Equivalent(
+                keyStore.KeyList(memberId1),
+                new List<KeyPair> {standard, lowNew, lowOld});
+
+            Assert.Equal(privileged, keyStore.GetByLevel(memberId2, Privileged));
+            Assert.Equal(privileged, keyStore.GetById(memberId2, privileged.Id));
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(directory, true);
+        }
+        
+        [Fact]
+        public void ReadFromFile()
+        {
+            var keyStore = new UnsecuredFileSystemKeyStore(directory);
+
+            Assert.Equal(standard, keyStore.GetByLevel(memberId1, Standard));
+            Assert.Equal(lowNew, keyStore.GetByLevel(memberId1, Low));
+            CollectionAssert.Equivalent(
+                keyStore.KeyList(memberId1),
+                new List<KeyPair> {standard, lowNew, lowOld});
+
+            Assert.Equal(privileged, keyStore.GetByLevel(memberId2, Privileged));
+            Assert.Equal(privileged, keyStore.GetById(memberId2, privileged.Id));
+        }
+    }
+}

--- a/core-tests/TestUtil.cs
+++ b/core-tests/TestUtil.cs
@@ -1,0 +1,39 @@
+﻿using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Tokenio;
+using Tokenio.Proto.Common.AliasProtos;
+using Tokenio.Proto.Common.SecurityProtos;
+using Tokenio.Security;
+using Tokenio.Utils;
+using static Tokenio.Proto.Common.AliasProtos.Alias.Types.Type;
+
+namespace Test
+{
+    public static class TestUtil
+    {
+        private static readonly IAsymmetricCipherKeyPairGenerator ed255519KeyGen;
+
+        static TestUtil()
+        {
+            ed255519KeyGen = GeneratorUtilities.GetKeyPairGenerator("Ed25519");
+            ed255519KeyGen.Init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        }
+
+        public static Alias Alias()
+        {
+            return new Alias
+            {
+                // use uppercase to test normalization
+                Value = Util.Nonce().ToUpper() + "+noverify@example.com",
+                Type = Email,
+                Realm = "token"
+            };
+        }
+        
+        public static KeyPair GenerateKeyPair(Key.Types.Level level)
+        {
+            return ed255519KeyGen.GenerateKeyPair().ParseEd25519KeyPair(level);
+        }
+    }
+}

--- a/core-tests/UtilityTest.cs
+++ b/core-tests/UtilityTest.cs
@@ -1,0 +1,59 @@
+﻿using System.Text;
+using Xunit;
+using Tokenio;
+using Tokenio.Proto.Common.AliasProtos;
+using Tokenio.Proto.Common.TokenProtos;
+using Tokenio.Security;
+using Tokenio.Utils;
+using static Tokenio.Proto.Common.AliasProtos.Alias.Types.Type;
+using static Tokenio.Proto.Common.TokenProtos.AccessBody.Types;
+using static Tokenio.Proto.Common.TokenProtos.AccessBody.Types.Resource.Types;
+
+namespace Test
+{
+    public class UtilityTest
+    {
+        [Fact]
+        public void JsonSerializer()
+        {
+            var payload = new TokenPayload
+            {
+                To = new TokenMember
+                {
+                    Id = "memberId"
+                },
+                Access = new AccessBody
+                {
+                    Resources =
+                    {
+                        new Resource
+                        {
+                            AllAddresses = new AllAddresses()
+                        }
+                    }
+                },
+                RefId = "refId"
+            };
+            var expected = "{\"access\":{\"resources\":[{\"allAddresses\":{}}]},\"refId\":\"refId\",\"to\":{\"id\":\"memberId\"}}";
+            Assert.Equal(expected, Util.ToJson(payload));
+        }
+
+        [Fact]
+        public void HashAlias()
+        {
+            var alias = new Alias
+            {
+                Type = Email,
+                Value = "bob@token.io"
+            };
+            Assert.Equal("HHzc3XVck27qD2gadGVzjffaBZrU8ZLEd2jmtcyPKeev", Util.NormalizeAndHashAlias(alias));
+        }
+
+        [Fact]
+        public void Base58Hashing()
+        {
+            var result = Base58.Encode(Encoding.UTF8.GetBytes("bob@token.io"));
+            Assert.Equal("2rjpGWoxbc8ASyDVx", result);
+        }
+    }
+}

--- a/core/src/Rpc/UnauthenticatedClient.cs
+++ b/core/src/Rpc/UnauthenticatedClient.cs
@@ -207,7 +207,7 @@ namespace Tokenio.Rpc
             operations.Add(Util.ToAddKeyOperation(cryptoEngine.GenerateKey(Level.Standard)));
             operations.Add(Util.ToAddKeyOperation(cryptoEngine.GenerateKey(Level.Low)));
 
-            var signer = cryptoEngine.CreateSigner(Level.Privileged);
+            var signer = cryptoEngine.CreateSigner(privilegedKey.Id);
             var memberRequest = new GetMemberRequest { MemberId = memberId };
             return gateway.GetMemberAsync(memberRequest)
                 .ToTask(response => response.Member)

--- a/core/src/Security/ICryptoEngine.cs
+++ b/core/src/Security/ICryptoEngine.cs
@@ -31,6 +31,13 @@ namespace Tokenio.Security
         ISigner CreateSigner(Level level);
 
         /// <summary>
+        /// Create a signer that signs data with a specific key.
+        /// </summary>
+        /// <param name="keyId">the key id</param>
+        /// <returns>the signer</returns>
+        ISigner CreateSigner(string keyId);
+
+        /// <summary>
         /// Create a verifier that verifies signatures with a specific key.
         /// </summary>
         /// <param name="keyId">the key id</param>

--- a/core/src/Security/Impl/TokenCryptoEngine.cs
+++ b/core/src/Security/Impl/TokenCryptoEngine.cs
@@ -52,6 +52,12 @@ namespace Tokenio.Security
             return new Ed25519Signer(keyPair.Id, keyPair.PrivateKey);
         }
 
+        public ISigner CreateSigner(string keyId)
+        {
+            var keyPair = keys.GetById(memberId, keyId);
+            return new Ed25519Signer(keyPair.Id, keyPair.PrivateKey);
+        }
+
         public IVerifier CreateVerifier(string keyId)
         {
             var keyPair = keys.GetById(memberId, keyId);

--- a/sdk-csharp.sln
+++ b/sdk-csharp.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TppSample", "tpp-sample\Tpp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tpp", "tpp\Tpp.csproj", "{EFA7309B-C0F8-499F-8496-44321155E363}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreTests", "core-tests\CoreTests.csproj", "{24EF2281-54F7-461E-91E6-42F8D4AC6B64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,5 +61,9 @@ Global
 		{EFA7309B-C0F8-499F-8496-44321155E363}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFA7309B-C0F8-499F-8496-44321155E363}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFA7309B-C0F8-499F-8496-44321155E363}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24EF2281-54F7-461E-91E6-42F8D4AC6B64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24EF2281-54F7-461E-91E6-42F8D4AC6B64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24EF2281-54F7-461E-91E6-42F8D4AC6B64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24EF2281-54F7-461E-91E6-42F8D4AC6B64}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/sdk/src/Security/ICryptoEngine.cs
+++ b/sdk/src/Security/ICryptoEngine.cs
@@ -20,7 +20,14 @@ namespace Tokenio.Security
         /// <param name="level">the key level</param>
         /// <returns>the signer</returns>
         ISigner CreateSigner(Level level);
-        
+
+        /// <summary>
+        /// Create a signer that signs data with a specific key.
+        /// </summary>
+        /// <param name="keyId">the key id</param>
+        /// <returns>the signer</returns>
+        ISigner CreateSigner(string keyId);
+
         /// <summary>
         /// Create a verifier that verifies signatures with a specific key.
         /// </summary>

--- a/sdk/src/Security/Impl/TokenCryptoEngine.cs
+++ b/sdk/src/Security/Impl/TokenCryptoEngine.cs
@@ -31,6 +31,12 @@ namespace Tokenio.Security
             return new Ed25519Signer(keyPair.Id, keyPair.PrivateKey);
         }
 
+        public ISigner CreateSigner(string keyId)
+        {
+            var keyPair = keys.GetById(memberId, keyId);
+            return new Ed25519Signer(keyPair.Id, keyPair.PrivateKey);
+        }
+
         public IVerifier CreateVerifier(string keyId)
         {
             var keyPair = keys.GetById(memberId, keyId);

--- a/tests/Security/CryptoEngineTest.cs
+++ b/tests/Security/CryptoEngineTest.cs
@@ -20,7 +20,7 @@ namespace Test.Security
             keyStore = new InMemoryKeyStore();
             cryptoEngine = new TokenCryptoEngine(memberId, keyStore);
         }
-        
+
         [Fact]
         public void VerifierTest()
         {
@@ -40,7 +40,7 @@ namespace Test.Security
             var verifier = cryptoEngine.CreateVerifier(signer.GetKeyId());
             verifier.Verify(payload, signature);
         }
-        
+
         [Fact]
         public void SignAndVerify_protobuf()
         {
@@ -62,6 +62,18 @@ namespace Test.Security
             var signature = signer.Sign(payload);
             var verifier = cryptoEngine.CreateVerifier(oldKey.Id);
             Assert.Throws<CryptographicException>(() => verifier.Verify(payload, signature));
+        }
+
+        [Fact]
+        public void useOldKey()
+        {
+            var oldKey = cryptoEngine.GenerateKey(Privileged);
+            cryptoEngine.GenerateKey(Privileged);
+            var signer = cryptoEngine.CreateSigner(oldKey.Id);
+            var payload = Util.Nonce();
+            var signature = signer.Sign(payload);
+            var verifier = cryptoEngine.CreateVerifier(oldKey.Id);
+            verifier.Verify(payload, signature);
         }
     }
 }


### PR DESCRIPTION
It's better to be two separate PRs, but the tests already include a test for the added method, and I am too lazy to separate them.
I will not squash the two commits.